### PR TITLE
added a new argument 'template' to markdownToHTML() to change the default template

### DIFF
--- a/R/renderMarkdown.R
+++ b/R/renderMarkdown.R
@@ -377,6 +377,7 @@ function(file, output, text, renderer='HTML', renderer.options=NULL,
 #'   in the output.
 #' @param header either valid HTML or a file containing HTML will be included in
 #'   the header of the output.
+#' @param template an HTML file used as template.
 #' @param fragment.only Whether or not to produce an HTML fragment without the
 #'   HTML header and body tags, CSS, and Javascript components.
 #' @return \code{renderMarkdown} returns NULL invisibly when output is to a
@@ -392,6 +393,7 @@ markdownToHTML <- function(file, output, text,
                            title='',
                            stylesheet=getOption('markdown.HTML.stylesheet'),
                            header=getOption('markdown.HTML.header', ''),
+                           template=getOption('markdown.HTML.template', system.file('resources/markdown.html',package='markdown')),
                            fragment.only=FALSE)
 {
    if (fragment.only==TRUE)
@@ -421,8 +423,7 @@ markdownToHTML <- function(file, output, text,
 
    if (!'fragment_only' %in% options)
    {
-      html <- paste(readLines(
-              system.file('resources/markdown.html',package='markdown')),collapse='\n')
+      html <- paste(readLines(template),collapse='\n')
       html <- sub('#!html_output#',ret,html,fixed=TRUE)
 
       if (is.character(stylesheet)){

--- a/man/markdownToHTML.Rd
+++ b/man/markdownToHTML.Rd
@@ -2,10 +2,14 @@
 \alias{markdownToHTML}
 \title{Render markdown to HTML}
 \usage{
-markdownToHTML(file, output, text, options = getOption("markdown.HTML.options"), 
-    extensions = getOption("markdown.extensions"), title = "", 
-    stylesheet = getOption("markdown.HTML.stylesheet"), 
-    header = getOption("markdown.HTML.header", ""), fragment.only = FALSE)
+  markdownToHTML(file, output, text,
+    options = getOption("markdown.HTML.options"),
+    extensions = getOption("markdown.extensions"),
+    title = "",
+    stylesheet = getOption("markdown.HTML.stylesheet"),
+    header = getOption("markdown.HTML.header", ""),
+    template = getOption("markdown.HTML.template", system.file("resources/markdown.html", package = "markdown")),
+    fragment.only = FALSE)
 }
 \arguments{
   \item{file}{a character string giving the pathname of the
@@ -35,6 +39,8 @@ markdownToHTML(file, output, text, options = getOption("markdown.HTML.options"),
 
   \item{header}{either valid HTML or a file containing HTML
   will be included in the header of the output.}
+
+  \item{template}{an HTML file used as template.}
 
   \item{fragment.only}{Whether or not to produce an HTML
   fragment without the HTML header and body tags, CSS, and
@@ -103,3 +109,4 @@ print(markdownToHTML(text = "Hello World!"))
   \code{\link{markdownHTMLOptions}},
   \code{\link{renderMarkdown}}.
 }
+


### PR DESCRIPTION
Changing the template is useful, for example, to surround the body with a `<div id="content"></div>` or some other markup (since the markdown to HTML conversion doesn't allow embedded HTML)
