### PR TITLE
now work with MBCS (tested on CP932) on windows.

### DIFF
--- a/R/renderMarkdown.R
+++ b/R/renderMarkdown.R
@@ -347,7 +347,7 @@ markdownToHTML <- function(
     }
 
     # Need to scrub title more, e.g. strip html, etc.
-    html <- sub('#!title#', title, html, perl = TRUE)
+    html <- sub('#!title#', title, html, fixed = TRUE)
 
     if ('highlight_code' %in% options && .requiresHighlighting(html)) {
       highlight <- paste(readLines(system.file(


### PR DESCRIPTION
Under locale=Japanese_Japan.CP932 (windows default in Japan), `markdownToHTML` sometimes fails.
This is because the line, `sub(perl=TRUE)` marks `html` as `UTF-8` (see `Encoding(html)`), and next call of `sub(fixed=TRUE)` a few lines below fails due to invalid multibyte string.

I think this is quite a simply bug, because `fixed=TRUE` in other calls of `sub` with a literal pattern.
Even worse we cannot run `knitr::knit2html` due to this bug.
This is very very serious... 

I hope this will be merged and `markdown` will be updated on CRAN soon.
Thanks,

kohske
