### PR TITLE
Fix/encode

### DIFF
--- a/R/renderMarkdown.R
+++ b/R/renderMarkdown.R
@@ -283,6 +283,7 @@ renderMarkdown <- function(
 #' @param template an HTML file used as template.
 #' @param fragment.only Whether or not to produce an HTML fragment without the
 #'   HTML header and body tags, CSS, and Javascript components.
+#' @param encoding the encoding of the input file; see \code{\link{file}}
 #' @return \code{renderMarkdown} returns NULL invisibly when output is to a
 #'   file, and a \code{character} vector otherwise.
 #' @seealso \code{\link{markdownExtensions}}, \code{\link{markdownHTMLOptions}},


### PR DESCRIPTION
`markdownToHTML` did not care encoding, so in some environments `knit2html` is not available.
Even worse, if windows user has utf-8 encoded .md file, he/she need to convert it into native.enc by hand.
This fix includes:
- `markdownToHTML` accepts `encoding` option.
- If `markdownToHTML` function is called from `knit2html`, it detect the encoding in `knit2html`
- output of `markdownToHTML` is always utf-8 (in the case of file output), in accordance with the meta-tag of HTML.

Please find the inline comments for more technical details.

The updated version has been tested with success under 
- OS X Snow Leopard, locale = "ja_JP.UTF8"
  - encoding: utf8 and CP932
- Windows 7, locale = "Japanese_Japan.CP932"
  - encoding: utf8 and CP932

I'm very very very happy if this fix will be merged and published on CRAN soon.

kohske
