### PR TITLE
add cainfo for rcurl in rpubsUpload

### DIFF
--- a/R/rpubsUpload.R
+++ b/R/rpubsUpload.R
@@ -278,7 +278,8 @@ rpubsUpload <- function(title,
                                        contentType = contentType))
 
       # use custom header and text gatherers
-      options <- RCurl::curlOptions(url)
+      sslpath <- system.file("CurlSSL", "cacert.pem", package = "RCurl")
+      options <- RCurl::curlOptions(url, cainfo = sslpath)
       headerGatherer <- RCurl::basicHeaderGatherer()
       options$headerfunction <- headerGatherer$update
       textGatherer <- RCurl::basicTextGatherer()


### PR DESCRIPTION
In R console (see `sessionInfo` below for context), trying to use `rpubsUpload` with `method='rcurl'` produces standard RCurl SSL error:

```
Error in function (type, msg, asError = TRUE)  : 
  SSL certificate problem, verify that the CA cert is OK. Details:
error:14090086:SSL routines:SSL3_GET_SERVER_CERTIFICATE:certificate verify failed
```

This pull request adds an explicit `cainfo` option to the `postForm` call to address this.

Here's `sessionInfo()` as context:

```
> sessionInfo()
R version 3.1.0 (2014-04-10)
Platform: x86_64-w64-mingw32/x64 (64-bit)

locale:
[1] LC_COLLATE=English_United States.1252  LC_CTYPE=English_United States.1252    LC_MONETARY=English_United States.1252 LC_NUMERIC=C                          
[5] LC_TIME=English_United States.1252    

attached base packages:
[1] tcltk     stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] RCurl_1.95-4.1    bitops_1.0-6      markdown_0.6.5    tcltk2_1.2-10     devtools_1.5.0.99

loaded via a namespace (and not attached):
[1] digest_0.6.4   evaluate_0.5.5 httr_0.3       memoise_0.2.1  parallel_3.1.0 stringr_0.6.2  tools_3.1.0    whisker_0.3-2
```
