### PR TITLE
Fixed .requiresMathJax() matching to code from the R syntax highligting script

### DIFF
--- a/R/renderMarkdown.R
+++ b/R/renderMarkdown.R
@@ -344,17 +344,17 @@ markdownToHTML <- function(
     # Need to scrub title more, e.g. strip html, etc.
     html <- sub('#!title#', title, html, fixed = TRUE)
 
+    if ('mathjax' %in% options && .requiresMathJax(html)) {
+      mathjax <- .mathJax(embed = 'mathjax_embed' %in% options)
+    } else mathjax <- ''
+    html <- sub('#!mathjax#', mathjax, html, fixed = TRUE)
+
     if ('highlight_code' %in% options && .requiresHighlighting(html)) {
       highlight <- paste(readLines(system.file(
         'resources', 'r_highlight.html', package = 'markdown'
       )), collapse = '\n')
     } else highlight <- ''
     html <- sub('#!r_highlight#', highlight, html, fixed = TRUE)
-
-    if ('mathjax' %in% options && .requiresMathJax(html)) {
-      mathjax <- .mathJax(embed = 'mathjax_embed' %in% options)
-    } else mathjax <- ''
-    html <- sub('#!mathjax#', mathjax, html, fixed = TRUE)
 
     ret <- html
   }


### PR DESCRIPTION
Moved the .requiresMathJax() check before the inclusion of the "R syntax highlighter" script to avoid false positive pattern match to the highlighter code. Otherwise, when the highlighter script was included also  MathJax libraries were enabled regardless of whether math expressions were actually present in the document or not.
