### PR TITLE
pick arbitrary contentLength if not returned by server (fixes #64)

### DIFF
--- a/R/rpubsUpload.R
+++ b/R/rpubsUpload.R
@@ -185,6 +185,9 @@ rpubsUpload <- function(title,
          }
       }
 
+      # Sometimes the server does not return the Content-Length header, pick arbitrary large number
+      if (is.null(contentLength)) contentLength = 100000
+
       # read the response content
       content <- rawToChar(readBin(conn, what = 'raw', n=contentLength))
 


### PR DESCRIPTION
Sometimes, the rpubs server doesn't return a content length. Since the n parameter can be an overestimate, it is safe to pick an arbitrary number here.

(see https://github.com/rstudio/markdown/issues/64)
