### PR TITLE
Misunderstood argument to bufnew()

### DIFF
--- a/src/Rbase64.c
+++ b/src/Rbase64.c
@@ -32,9 +32,9 @@ SEXP rmd_b64encode_data( SEXP Sdata)
    struct buf *databuf;
    const char* str;
 
-   /* We don't know the size of the encoded output, but
-      we know that it is at least as long as the input */
-   databuf = bufnew(data_len);
+   /* Create a buffer that grows READ_UNIT bytes at
+      the time as a larger buffer is needed */
+   databuf = bufnew(READ_UNIT);
    if (!databuf)
    {
       RMD_WARNING_NOMEM;
@@ -53,9 +53,7 @@ SEXP rmd_b64encode_data( SEXP Sdata)
       }
       if( len ) {
          encodeblock( in, out, len );
-         for( i = 0; i < 4; i++ ) {
-            bufputc(databuf,out[i]);
-         }
+         bufput(databuf,out,4);
       }
    }
 


### PR DESCRIPTION
Updates:

* Misunderstood argument to `bufnew()` - it's not the initial size but the growth unit [#73,#75]
* Use `bufput()` once instead of `bufputc()` iteratively.

None of these are critical, and my PR #75 did not introduce a bug, but the code + comments may be misleading to future developers.

A clarification to my previous release of rights in PR #75 to avoid having to repeat this all the time:  
I hereby give the copy-right holder of the markdown package all the rights (including copy rights) to all my contributions part of _all_ pull requests _and code in issues_ to this repository.
_