### PR TITLE
Clean sourcepos records when they come from metadata.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # CHANGES IN markdown VERSION 1.13
 
+- Cleaned `sourcepos` records when they come from metadata (thanks, @dmurdoch, #111).
 
 # CHANGES IN markdown VERSION 1.12
 

--- a/R/render.R
+++ b/R/render.R
@@ -106,7 +106,7 @@ mark = function(
   render = function(x, clean = FALSE) {
     if (length(x) == 0) return(x)
     res = do.call(render_fun, c(list(text = x), render_args))
-    if (clean) res = gsub('^<p>|(</p>)?\n$', '', res)
+    if (clean) res = gsub('^<p[^>]*>|(</p>)?\n$', '', res)
     res
   }
 


### PR DESCRIPTION
NB:  the sourcepos records refer to the intermediate .md file, not the .Rmd file.  I'll be updating the RmdConcord package to correct these based on the knitr concordance record.

I looked into the possibility of keeping the metadata sourcepos records, but it's just too much trouble.